### PR TITLE
Missing dependency for NamespaceClassLoader

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,11 @@ By default, this extension ships with two Feed Types:
 2. Google Merchant (formerly known as Google Base or also Google Shopping)
 
 Note: In order to create a properly formatted Google Merchant feed, you will need to fill out the additional information on your products in the product management section.
+
+## Dependencies
+
+Built for
+* https://github.com/isotope/core
+
+If you aren't using Composer for installation, you need to install:
+* https://github.com/terminal42/contao-NamespaceClassLoader

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,14 @@
     "php":">=5.3",
     "contao/core": "~3.2",
     "contao-community-alliance/composer-plugin": "~2.4",
-    "isotope/isotope-core": "~2.2",
-    "terminal42/contao-namespace-class-loader": "~1.0"
+    "isotope/isotope-core": "~2.2"
+  },
+  "autoload": {
+    "psr-0": {
+        "Rhyme\\": [
+          "system/modules/isotope_feeds/library"
+        ]
+    },
   },
   "extra":{
     "contao": {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "php":">=5.3",
     "contao/core": "~3.2",
     "contao-community-alliance/composer-plugin": "~2.4",
-    "isotope/isotope-core": "~2.2"
+    "isotope/isotope-core": "~2.2",
+    "terminal42/contao-namespace-class-loader": "~1.0"
   },
   "extra":{
     "contao": {

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -12,7 +12,10 @@
 /**
  * Register namespace
  */
-NamespaceClassLoader::add('Rhyme', 'system/modules/isotope_feeds/library');
+if (class_exists('NamespaceClassLoader'))
+{
+    NamespaceClassLoader::add('Rhyme', 'system/modules/isotope_feeds/library');
+}
 
 
 /**


### PR DESCRIPTION
Using composer’s autoloading will do it too but this solution is the uncomplicated one
