### PR TITLE
Add missing use statements

### DIFF
--- a/library/Rhyme/Hooks/ExecutePreActions/IsotopeFeeds.php
+++ b/library/Rhyme/Hooks/ExecutePreActions/IsotopeFeeds.php
@@ -12,6 +12,8 @@
 
 namespace Rhyme\Hooks\ExecutePreActions;
 
+use Isotope\Isotope;
+use Isotope\Model\ProductCollection\Cart;
 use Rhyme\IsotopeFeeds as IsoFeeds;
 use Haste\Http\Response\JsonResponse;
 use Isotope\Model\Product;


### PR DESCRIPTION
Adds the missing `use` statements from this commit: https://github.com/RhymeDigital/isotope_feeds/commit/c74514a73deaf56e47226fa63c4cc39fdb3ce65e.