### PR TITLE
Fix an issue with php72 (count())

### DIFF
--- a/library/Rhyme/FeedItem/GoogleMerchant.php
+++ b/library/Rhyme/FeedItem/GoogleMerchant.php
@@ -70,7 +70,7 @@ class GoogleMerchant extends Rss20
 		
 		foreach($arrGoogleFields as $strKey)
 		{
-			if($this->__isset($strKey) && count($this->$strKey) )
+			if($this->__isset($strKey))
 			{
 				if(is_array($this->$strKey) && count($this->$strKey))
 				{


### PR DESCRIPTION
Fixes following issue on PHP 7.2 while generating the feed cache:
```
Warning: count(): Parameter must be an array or an object that implements Countable in system/modules/isotope_feeds/library/Rhyme/FeedItem/GoogleMerchant.php on line 73
```