### PR TITLE
Fix SKU and feed_legend

### DIFF
--- a/src/Helper/IsotopeFeeds.php
+++ b/src/Helper/IsotopeFeeds.php
@@ -365,7 +365,7 @@ class IsotopeFeeds extends Controller
 
 			//Sku, price, etc
 			$objItem->id = $objProduct->id;
-			$objItem->sku = strlen($objProduct->sku) ? $objProduct->sku : $objProduct->alias;
+			$objItem->sku = ($objProduct->sku && strlen($objProduct->sku)) ? $objProduct->sku : $objProduct->alias;
 			$objItem->price = Isotope::formatPriceWithCurrency($objProduct->getPrice(Isotope::getCart())->getAmount(), false);
 
 			//Google basic settings

--- a/src/Resources/contao/dca/tl_layout.php
+++ b/src/Resources/contao/dca/tl_layout.php
@@ -8,10 +8,18 @@ declare(strict_types=1);
  * @license LGPL-3.0+
  */
 
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
+
 /**
  * Palettes
  */
-$GLOBALS['TL_DCA']['tl_layout']['palettes']['default'] = str_replace('calendarfeeds','calendarfeeds,productfeeds',$GLOBALS['TL_DCA']['tl_layout']['palettes']['default']);
+
+// Extend default palette
+PaletteManipulator::create()
+    ->addLegend('feed_legend', 'modules_legend', PaletteManipulator::POSITION_BEFORE)
+    ->addField('productfeeds', 'feed_legend', PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('default', 'tl_layout')
+;
 
 /**
  * Fields


### PR DESCRIPTION
In the installation of our customer we don't have any SKU's so you can't just use `strlen` on a property that might not be a string. Furthermore our installation lacks the `calendar-bundle` (we don't need it in this case) so there is no `feed_legend` present in `tl_layout`.