### PR TITLE
Add in additional optional fields for Google Merchant center

### DIFF
--- a/src/Helper/IsotopeFeeds.php
+++ b/src/Helper/IsotopeFeeds.php
@@ -45,6 +45,11 @@ class IsotopeFeeds extends Controller
      */
     protected static $arrXMLDirCache = array();
 
+	public function __construct()
+    {
+        parent::__construct();
+    }
+
     /**
 	 * Return a feed name from a config
 	 * @param mixed \Isotope\Model\Config or Contao\DatabaseResult


### PR DESCRIPTION
As we use `IsotopeFeeds` non-static methods in our code to generate feed items and feeds, the constructor should be public (instead of protected):

```php
// ...
$isotopeFeeds = new IsotopeFeeds();
$isotopeFeeds->generateProductXML($feedFile, $current, $config);
// ...
$feeds = new IsotopeFeeds();
$feeds->generateFeeds();
// ...
```

We could also make the methods static callable, but I think this is less of a change and will not change any signatures :)

@blairwinans what do you think?