### PR TITLE
Add null check

### DIFF
--- a/src/Resources/contao/dca/tl_iso_config.php
+++ b/src/Resources/contao/dca/tl_iso_config.php
@@ -16,7 +16,7 @@ use Contao\System;
 
 $GLOBALS['TL_DCA']['tl_iso_config']['config']['onsubmit_callback'][] = array('Rhyme\IsotopeFeedsBundle\Helper\IsotopeFeeds', 'generateFeeds');
 $GLOBALS['TL_DCA']['tl_iso_config']['palettes']['__selector__'][] = 'addFeed';
-$GLOBALS['TL_DCA']['tl_iso_config']['palettes']['default'] = str_replace('{analytics_legend}', '{feed_legend},addFeed;{images_legend}', $GLOBALS['TL_DCA']['tl_iso_config']['palettes']['default']);
+$GLOBALS['TL_DCA']['tl_iso_config']['palettes']['default'] = str_replace('{analytics_legend}', '{feed_legend},addFeed;{images_legend}', $GLOBALS['TL_DCA']['tl_iso_config']['palettes']['default'] ?? '');
 $GLOBALS['TL_DCA']['tl_iso_config']['subpalettes']['addFeed'] = 'feedTypes,feedName,feedBase,feedLanguage,feedTitle,feedDesc,feedJumpTo';
 
 


### PR DESCRIPTION
Under PHP 8 on CLI it can happen that `$GLOBALS['TL_DCA']['tl_iso_config']['palettes']['default']` is not yet available.