### PR TITLE
Fix undefined array key error

### DIFF
--- a/src/Helper/IsotopeFeeds.php
+++ b/src/Helper/IsotopeFeeds.php
@@ -77,7 +77,7 @@ class IsotopeFeeds extends Controller
 	 */
 	public static function getCacheDirectories($objConfig)
 	{
-    	if(!is_array(static::$arrXMLDirCache[$objConfig->id]))
+    	if(!is_array(static::$arrXMLDirCache[$objConfig->id] ?? null))
     	{
         	$arrFeedTypes = StringUtil::deserialize($objConfig->feedTypes, true);
     		foreach( $arrFeedTypes as $feedType )
@@ -107,7 +107,7 @@ class IsotopeFeeds extends Controller
 	 */
 	public static function getFeedFiles($objConfig)
 	{
-    	if(!is_array(static::$arrFeedCache[$objConfig->id]))
+    	if(!is_array(static::$arrFeedCache[$objConfig->id] ?? null))
     	{
         	static::$arrFeedCache[$objConfig->id] = array();
         	$strBase = static::getFeedBaseName($objConfig);


### PR DESCRIPTION
Fixes #44 

Stacktrace:
```
ErrorException:
Warning: Undefined array key 1

  at vendor/rhymedigital/isotope-feeds/src/Helper/IsotopeFeeds.php:110
  at Rhyme\IsotopeFeedsBundle\Helper\IsotopeFeeds::getFeedFiles()
     (vendor/rhymedigital/isotope-feeds/src/Helper/IsotopeFeeds.php:190)
  at Rhyme\IsotopeFeedsBundle\Helper\IsotopeFeeds->generateFeeds()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:2819)
  at Contao\DC_Table->toggle()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Ajax.php:456)
  at Contao\Ajax->executePostActions()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:430)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:44)       
```