### PR TITLE
Fix incorrect legend in palette

### DIFF
--- a/src/Resources/contao/dca/tl_iso_config.php
+++ b/src/Resources/contao/dca/tl_iso_config.php
@@ -12,11 +12,17 @@ declare(strict_types=1);
  * Table tl_iso_config
  */
 
+use Contao\CoreBundle\DataContainer\PaletteManipulator;
 use Contao\System;
+
+PaletteManipulator::create()
+    ->addLegend('feed_legend', 'analytics_legend', PaletteManipulator::POSITION_BEFORE)
+    ->addField('addFeed', 'feed_legend', PaletteManipulator::POSITION_APPEND)
+    ->applyToPalette('default', 'tl_iso_config')
+;
 
 $GLOBALS['TL_DCA']['tl_iso_config']['config']['onsubmit_callback'][] = array('Rhyme\IsotopeFeedsBundle\Helper\IsotopeFeeds', 'generateFeeds');
 $GLOBALS['TL_DCA']['tl_iso_config']['palettes']['__selector__'][] = 'addFeed';
-$GLOBALS['TL_DCA']['tl_iso_config']['palettes']['default'] = str_replace('{analytics_legend}', '{feed_legend},addFeed;{images_legend}', $GLOBALS['TL_DCA']['tl_iso_config']['palettes']['default']);
 $GLOBALS['TL_DCA']['tl_iso_config']['subpalettes']['addFeed'] = 'feedTypes,feedName,feedBase,feedLanguage,feedTitle,feedDesc,feedJumpTo';
 
 


### PR DESCRIPTION
The analytics_legend is incorrectly replaced with images_legend. This causes an incorrect label. 
I have also replaced the str_replace with the more robust PaletteManipulator.

Before:
<img width="436" alt="image" src="https://github.com/user-attachments/assets/2eb65ff7-1700-4f25-a1e5-ea11a34cb41a" />

After:
<img width="368" alt="image" src="https://github.com/user-attachments/assets/b123f806-6f9f-4047-af3e-c1e3ba0d420b" />