### PR TITLE
Remove references to TL_CONFIG websiteTitle

### DIFF
--- a/src/Backend/IsotopeProduct/FeedCache.php
+++ b/src/Backend/IsotopeProduct/FeedCache.php
@@ -71,8 +71,6 @@ class FeedCache extends Backend
             $this->objAjax->executePreActions();
         }
 
-        $this->Template->headline = $GLOBALS['TL_CONFIG']['websiteTitle'];
-
         $this->Template->rt = $container->get('contao.csrf.token_manager')->getToken($container->getParameter('contao.csrf_token_name'))->getValue();
 
         $this->Template->startMsg = 'Starting';
@@ -82,14 +80,11 @@ class FeedCache extends Backend
         $this->Template->theme = $this->getTheme();
         $this->Template->base = Environment::get('base');
         $this->Template->language = $GLOBALS['TL_LANGUAGE'];
-        $this->Template->title = $GLOBALS['TL_CONFIG']['websiteTitle'];
-        $this->Template->charset = $GLOBALS['TL_CONFIG']['characterSet'];
         $this->Template->pageOffset = $this->Input->cookie('BE_PAGE_OFFSET');
         $this->Template->error = ($this->Input->get('act') == 'error') ? $GLOBALS['TL_LANG']['ERR']['general'] : '';
         $this->Template->skipNavigation = $GLOBALS['TL_LANG']['MSC']['skipNavigation'];
         $this->Template->request = ampersand(Environment::get('request'));
         $this->Template->top = $GLOBALS['TL_LANG']['MSC']['backToTop'];
-        $this->Template->be27 = !$GLOBALS['TL_CONFIG']['oldBeTheme'];
         $this->Template->expandNode = $GLOBALS['TL_LANG']['MSC']['expandNode'];
         $this->Template->collapseNode = $GLOBALS['TL_LANG']['MSC']['collapseNode'];
 


### PR DESCRIPTION
`$GLOBALS['TL_CONFIG']['websiteTitle']` doesn't exist anymore. Isn't really needed here anyway, so I removed it aswell as the characterSet and oldBeTheme.

This PR fixes the following stacktrace:
```
ErrorException:
Warning: Undefined array key "websiteTitle"

  at vendor/rhymedigital/isotope-feeds/src/Backend/IsotopeProduct/FeedCache.php:75
  at Rhyme\IsotopeFeedsBundle\Backend\IsotopeProduct\FeedCache->run()
     (vendor/rhymedigital/isotope-feeds/src/Controller/FeedController.php:45)
  at Rhyme\IsotopeFeedsBundle\Controller\FeedController->feedCacheAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:44)
```