### PR TITLE
Fix TypeError if $strDescription is null

### DIFF
--- a/src/Helper/IsotopeFeeds.php
+++ b/src/Helper/IsotopeFeeds.php
@@ -419,7 +419,7 @@ class IsotopeFeeds extends Controller
 			} else {
 			    $strDescription = $objProduct->description;
 			}
-			$strDescription = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($strDescription);
+			$strDescription = System::getContainer()->get('contao.insert_tag.parser')->replaceInline($strDescription ?? '');
 			$objItem->description = $this->convertRelativeUrls($strDescription, $strLink);
 
 			//Sku, price, etc


### PR DESCRIPTION
If a product is saved without a description, the following stacktrace will occur.
This PR fixes the issue.

```
TypeError:
Contao\CoreBundle\InsertTag\InsertTagParser::replaceInline(): Argument #1 ($input) must be of type string, null given, called in /var/customers/webs/..../vendor/rhymedigital/isotope-feeds/src/Helper/IsotopeFeeds.php on line 422

  at vendor/contao/core-bundle/src/InsertTag/InsertTagParser.php:40
  at Contao\CoreBundle\InsertTag\InsertTagParser->replaceInline()
     (vendor/rhymedigital/isotope-feeds/src/Helper/IsotopeFeeds.php:422)
  at Rhyme\IsotopeFeedsBundle\Helper\IsotopeFeeds->generateProductXML()
     (vendor/rhymedigital/isotope-feeds/src/Helper/IsotopeFeeds.php:236)
  at Rhyme\IsotopeFeedsBundle\Helper\IsotopeFeeds->cacheProduct()
     (vendor/rhymedigital/isotope-feeds/src/Backend/IsotopeProduct/FeedCallbacks.php:86)
  at Rhyme\IsotopeFeedsBundle\Backend\IsotopeProduct\FeedCallbacks->cacheProduct()
     (vendor/rhymedigital/isotope-feeds/src/Backend/IsotopeProduct/FeedCallbacks.php:98)
  at Rhyme\IsotopeFeedsBundle\Backend\IsotopeProduct\FeedCallbacks->toggleProduct()
     (vendor/contao/core-bundle/src/Resources/contao/drivers/DC_Table.php:3293)
  at Contao\DC_Table->save()
     (vendor/contao/core-bundle/src/Resources/contao/classes/DataContainer.php:523)
  at Contao\DataContainer->row()
     (vendor/isotope/isotope-core/system/modules/isotope/drivers/DC_ProductData.php:644)
  at DC_ProductData->edit()
     (vendor/contao/core-bundle/src/Resources/contao/classes/Backend.php:667)
  at Contao\Backend->getBackendModule()
     (vendor/contao/core-bundle/src/Resources/contao/controllers/BackendMain.php:168)
  at Contao\BackendMain->run()
     (vendor/contao/core-bundle/src/Controller/BackendController.php:49)
  at Contao\CoreBundle\Controller\BackendController->mainAction()
     (vendor/symfony/http-kernel/HttpKernel.php:163)
  at Symfony\Component\HttpKernel\HttpKernel->handleRaw()
     (vendor/symfony/http-kernel/HttpKernel.php:75)
  at Symfony\Component\HttpKernel\HttpKernel->handle()
     (vendor/symfony/http-kernel/Kernel.php:202)
  at Symfony\Component\HttpKernel\Kernel->handle()
     (public/index.php:44)        
```